### PR TITLE
Updated to use correct object

### DIFF
--- a/utils/storyblok.js
+++ b/utils/storyblok.js
@@ -30,7 +30,7 @@ export function useStoryblok(originalStory, preview, locale) {
 
       // live update the story on input events
       storyblokInstance.on("input", (event) => {
-        if (story && event.story._uid === story._uid) {
+        if (story && event.story.content._uid === story.content._uid) {
           setStory(event.story);
         }
       });


### PR DESCRIPTION
Hi Team,

While implementing typescript in my project I kept running into errors when trying to access _uid on story.

After a fair bit of digging. I realised that on the live update event you are currently trying to access _uid on the story object when it actually exists only on story.content.

The code works because both values are undefined so match.

I thought I would add a PR to hopefully prevent anyone else getting confused in the future.